### PR TITLE
Added Golly rules for Shockwave

### DIFF
--- a/emulators/Golly/Shockwave1D.rule
+++ b/emulators/Golly/Shockwave1D.rule
@@ -1,0 +1,27 @@
+@RULE Shockwave1D
+
+@TABLE
+
+n_states:4
+neighborhood:Moore
+symmetries:reflect_horizontal
+var a={0,1,2,3}
+var b={0,1,2,3}
+var c={0,1,2,3}
+var d={0,1,2,3}
+var e={0,1,2,3}
+var f={0,1,2,3}
+var g={0,1,2,3}
+
+0,0,1,a,b,c,d,e,f,1
+0,1,a,b,c,d,e,f,g,2
+0,2,1,a,b,c,d,e,f,0
+0,2,a,b,c,d,e,f,g,1
+0,3,a,b,c,d,e,f,g,3
+
+@COLORS
+
+0  48  48  48   dark gray
+1 255 255 255   white
+2   0 255   0   green
+3 128 128 128   gray

--- a/emulators/Golly/Shockwave2D-alt.rule
+++ b/emulators/Golly/Shockwave2D-alt.rule
@@ -1,0 +1,23 @@
+@RULE Shockwave2D-alt
+
+@TABLE
+
+n_states:4
+neighborhood:vonNeumann
+symmetries:permute
+var a={0,1,2,3}
+var b={0,1,2,3}
+var c={0,1,2,3}
+var d={0,1,2,3}
+
+0,1,a,b,c,1
+1,a,b,c,d,2
+2,1,a,b,c,0
+2,a,b,c,d,1
+
+@COLORS
+
+0  48  48  48   dark gray
+1 255 255 255   white
+2   0 255   0   green
+3 128 128 128   gray

--- a/emulators/Golly/Shockwave2D.rule
+++ b/emulators/Golly/Shockwave2D.rule
@@ -1,0 +1,27 @@
+@RULE Shockwave2D
+
+@TABLE
+
+n_states:4
+neighborhood:Moore
+symmetries:permute
+var a={0,1,2,3}
+var b={0,1,2,3}
+var c={0,1,2,3}
+var d={0,1,2,3}
+var e={0,1,2,3}
+var f={0,1,2,3}
+var g={0,1,2,3}
+var h={0,1,2,3}
+
+0,1,b,c,d,e,f,g,h,1
+1,a,b,c,d,e,f,g,h,2
+2,1,b,c,d,e,f,g,h,0
+2,a,b,c,d,e,f,g,h,1
+
+@COLORS
+
+0  48  48  48   dark gray
+1 255 255 255   white
+2   0 255   0   green
+3 128 128 128   gray


### PR DESCRIPTION
Shockwave1D rulefile implements 1D shockwave, Shockwave2D implements 2D
shockwave using Moore neighborhoods, and Shockwave2D-alt does 2D
shockwave using Von Neumann neighborhoods. White is A, Green is B, and
Gray represents perma-zeroes.

Signed-off-by: ZweiSpeedruns <zcm727@gmail.com>